### PR TITLE
Don't hide text when rendering on the server side

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -202,7 +202,7 @@
 
                 var props = _objectWithoutProperties(_props, ['text', 'truncateText', 'line', 'showTitle', 'textTruncateChild', 'containerClassName']);
 
-                var renderText = '';
+                var renderText = text;
                 if (this.refs.scope) {
                     renderText = this.getRenderText();
                 }

--- a/src/TextTruncate.js
+++ b/src/TextTruncate.js
@@ -122,7 +122,7 @@ export default class TextTruncate extends Component {
             ...props
         } = this.props;
 
-        let renderText = '';
+        let renderText = text;
         if (this.refs.scope) {
             renderText = this.getRenderText();
         }


### PR DESCRIPTION
If we're using react-text-truncate on the server side `refs.scope` is undefined and we're getting a container without the text.