### PR TITLE
Wrong truncating when a container has long words without spaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -173,6 +173,7 @@
                 var displayLine = line;
                 var width = 0;
                 var lastIsEng = false;
+                var lastSpaceIndex = -1;
 
                 while (displayLine--) {
                     var ext = displayLine ? '' : truncateText + ' ' + childText;
@@ -196,8 +197,11 @@
                                     truncatedText = text.substr(startPos, currentPos - 1);
                                 }
                                 if (lastIsEng) {
-                                    currentPos = truncatedText.lastIndexOf(' ');
-                                    truncatedText = text.substr(startPos, currentPos);
+                                    lastSpaceIndex = truncatedText.lastIndexOf(' ');
+                                    if (lastSpaceIndex > -1) {
+                                        currentPos = lastSpaceIndex;
+                                        truncatedText = text.substr(startPos, currentPos);
+                                    }
                                 }
                                 width = this.measureWidth(truncatedText + ext);
                             } while (width >= scopeWidth);

--- a/src/App.js
+++ b/src/App.js
@@ -92,6 +92,12 @@ export class App extends Component {
                         <h5>5. Block-level textTruncateChild</h5>
                         <TextTruncate {...props} textTruncateChild={<div>Block level child</div>}/>
                     </div>
+                    <div id='sample-6'>
+                        <h5>6. Long words inside a small container</h5>
+                        <div style={{
+                            width: 150
+                        }}><TextTruncate line={3} text="Национал-Большевизм. Сталинская массовая культура и формирование русского национального самосознания (1931-1956)" /></div>
+                    </div>
                 </div>
             </div>
         )

--- a/src/TextTruncate.js
+++ b/src/TextTruncate.js
@@ -88,6 +88,7 @@ export default class TextTruncate extends Component {
         let displayLine = line;
         let width = 0;
         let lastIsEng = false;
+        let lastSpaceIndex = -1;
 
         while (displayLine--) {
             let ext = displayLine ? '' : truncateText + ' ' + childText;
@@ -111,8 +112,11 @@ export default class TextTruncate extends Component {
                             truncatedText = text.substr(startPos, currentPos - 1);
                         }
                         if (lastIsEng) {
-                            currentPos = truncatedText.lastIndexOf(' ');
-                            truncatedText = text.substr(startPos, currentPos);
+                            lastSpaceIndex = truncatedText.lastIndexOf(' ');
+                            if (lastSpaceIndex > -1) {
+                                currentPos = lastSpaceIndex;
+                                truncatedText = text.substr(startPos, currentPos);
+                            }
                         }
                         width = this.measureWidth(truncatedText + ext);
                     } while (width >= scopeWidth);


### PR DESCRIPTION
Fixes #31. See an example.