### PR TITLE
Replace includes method for ie11 compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@
         _inherits(TextTruncate, _Component);
 
         function TextTruncate() {
-            var _Object$getPrototypeO;
+            var _ref;
 
             var _temp, _this, _ret;
 
@@ -99,7 +99,7 @@
                 args[_key] = arguments[_key];
             }
 
-            return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(TextTruncate)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.onResize = function () {
+            return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TextTruncate.__proto__ || Object.getPrototypeOf(TextTruncate)).call.apply(_ref, [this].concat(args))), _this), _this.onResize = function () {
                 window.requestAnimationFrame(_this.update.bind(_this));
             }, _this.update = function () {
                 _this.forceUpdate();
@@ -160,7 +160,8 @@
 
                 var childText = '';
                 if (textTruncateChild && typeof textTruncateChild.type === 'string') {
-                    if (['span', 'a'].includes(textTruncateChild.type)) {
+                    var type = textTruncateChild.type;
+                    if (type.indexOf('span') >= 0 || type.indexOf('a') >= 0) {
                         childText = textTruncateChild.props.children;
                     }
                 }

--- a/src/TextTruncate.js
+++ b/src/TextTruncate.js
@@ -75,7 +75,8 @@ export default class TextTruncate extends Component {
 
         let childText = '';
         if (textTruncateChild && typeof textTruncateChild.type === 'string') {
-            if (['span', 'a'].includes(textTruncateChild.type)) {
+            let type = textTruncateChild.type;
+            if (type.indexOf('span') >= 0 || type.indexOf('a') >= 0) {
                 childText = textTruncateChild.props.children;
             }
         }


### PR DESCRIPTION
I was seeing the following error when testing in Internet Explorer 11:

![pasted_image_at_2016_09_21_01_45_pm](https://cloud.githubusercontent.com/assets/183812/18733120/35fe2d50-801d-11e6-9f65-84b447b64500.png)

According to the [MDN reference page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility) the `includes` method is not supported in Internet Explorer. `indexOf` can easily be used instead, which will provide compatibility with ie >= 11.