### PR TITLE
fix infinite loop when width is too small to display truncateText

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,7 +205,7 @@
                                     }
                                 }
                                 width = this.measureWidth(truncatedText + ext);
-                            } while (width >= scopeWidth);
+                            } while (width >= scopeWidth && truncatedText.length > 0);
                             startPos += currentPos;
                             break;
                         }

--- a/src/TextTruncate.js
+++ b/src/TextTruncate.js
@@ -120,7 +120,7 @@ export default class TextTruncate extends Component {
                             }
                         }
                         width = this.measureWidth(truncatedText + ext);
-                    } while (width >= scopeWidth);
+                    } while (width >= scopeWidth && truncatedText.length > 0);
                     startPos += currentPos;
                     break;
                 }


### PR DESCRIPTION
This is a PR commiting @kaiw's fix to an infinite loop in `getRenderText`, taken from the original issue:
https://github.com/ShinyChang/React-Text-Truncate/issues/38