### PR TITLE
React 15.5 React.PropTypes deprecation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,16 @@
 (function (global, factory) {
     if (typeof define === "function" && define.amd) {
-        define(['module', 'exports', 'react'], factory);
+        define(['module', 'exports', 'react', 'prop-types'], factory);
     } else if (typeof exports !== "undefined") {
-        factory(module, exports, require('react'));
+        factory(module, exports, require('react'), require('prop-types'));
     } else {
         var mod = {
             exports: {}
         };
-        factory(mod, mod.exports, global.React);
+        factory(mod, mod.exports, global.React, global.propTypes);
         global.TextTruncate = mod.exports;
     }
-})(this, function (module, exports, _react) {
+})(this, function (module, exports, _react, _propTypes) {
     'use strict';
 
     Object.defineProperty(exports, "__esModule", {
@@ -18,6 +18,8 @@
     });
 
     var _react2 = _interopRequireDefault(_react);
+
+    var _propTypes2 = _interopRequireDefault(_propTypes);
 
     function _interopRequireDefault(obj) {
         return obj && obj.__esModule ? obj : {
@@ -133,14 +135,13 @@
         }, {
             key: 'getRenderText',
             value: function getRenderText() {
-                var _props = this.props;
-                var containerClassName = _props.containerClassName;
-                var line = _props.line;
-                var text = _props.text;
-                var textTruncateChild = _props.textTruncateChild;
-                var truncateText = _props.truncateText;
-
-                var props = _objectWithoutProperties(_props, ['containerClassName', 'line', 'text', 'textTruncateChild', 'truncateText']);
+                var _props = this.props,
+                    containerClassName = _props.containerClassName,
+                    line = _props.line,
+                    text = _props.text,
+                    textTruncateChild = _props.textTruncateChild,
+                    truncateText = _props.truncateText,
+                    props = _objectWithoutProperties(_props, ['containerClassName', 'line', 'text', 'textTruncateChild', 'truncateText']);
 
                 var scopeWidth = this.refs.scope.getBoundingClientRect().width;
 
@@ -230,9 +231,9 @@
         }, {
             key: 'render',
             value: function render() {
-                var _props2 = this.props;
-                var text = _props2.text;
-                var containerClassName = _props2.containerClassName;
+                var _props2 = this.props,
+                    text = _props2.text,
+                    containerClassName = _props2.containerClassName;
 
 
                 var renderText = text;
@@ -252,11 +253,11 @@
     }(_react.Component);
 
     TextTruncate.propTypes = {
-        containerClassName: _react2.default.PropTypes.string,
-        line: _react2.default.PropTypes.number,
-        text: _react2.default.PropTypes.string,
-        textTruncateChild: _react2.default.PropTypes.node,
-        truncateText: _react2.default.PropTypes.string
+        containerClassName: _propTypes2.default.string,
+        line: _propTypes2.default.number,
+        text: _propTypes2.default.string,
+        textTruncateChild: _propTypes2.default.node,
+        truncateText: _propTypes2.default.string
     };
     TextTruncate.defaultProps = {
         line: 1,

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   "peerDependencies": {
     "react": "^0.14.7 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.4"
   }
 }

--- a/src/TextTruncate.js
+++ b/src/TextTruncate.js
@@ -1,12 +1,13 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 export default class TextTruncate extends Component {
     static propTypes = {
-        containerClassName: React.PropTypes.string,
-        line: React.PropTypes.number,
-        text: React.PropTypes.string,
-        textTruncateChild: React.PropTypes.node,
-        truncateText: React.PropTypes.string
+        containerClassName: PropTypes.string,
+        line: PropTypes.number,
+        text: PropTypes.string,
+        textTruncateChild: PropTypes.node,
+        truncateText: PropTypes.string
     };
 
     static defaultProps = {


### PR DESCRIPTION
Follow up to https://github.com/ShinyChang/React-Text-Truncate/pull/42 , PropTypes [extraced](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) to a separate [repo](https://www.npmjs.com/package/prop-types)