### PR TITLE
Fix async this.forceUpdate() issue caused by requestAnimationFrame delay

### DIFF
--- a/src/TextTruncate.js
+++ b/src/TextTruncate.js
@@ -1,6 +1,10 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+const requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
+                              window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
+const cancelAnimationFrame = window.cancelAnimationFrame || window.mozCancelAnimationFrame;
+
 export default class TextTruncate extends Component {
     static propTypes = {
         containerClassName: PropTypes.string,
@@ -36,10 +40,16 @@ export default class TextTruncate extends Component {
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.onResize);
+        if (this.rafId) {
+          cancelAnimationFrame(this.rafId);
+        }
     }
 
     onResize = () => {
-        window.requestAnimationFrame(this.update.bind(this))
+        if (this.rafId) {
+          cancelAnimationFrame(this.rafId);
+        }
+        this.rafId = requestAnimationFrame(this.update.bind(this))
     };
 
     update = () => {


### PR DESCRIPTION
![2017-05-17 4 11 49](https://cloud.githubusercontent.com/assets/811518/26144509/b2a30c9a-3b1b-11e7-8778-9ffe4ec8457e.png)

This happens when you're actively unmounting components. In my case, this happens when I remove components on window resize. It seems that the component is already unmounted when `requestAnimationFrame` finally fired.

I have this fixed by canceling the animation frame with the returned id on component unmount.