### PR TITLE
Recover missing change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 ## Changelog
+* 0.13.1 Fix react warning of `maxCalculateTimes`
+* 0.13.0 Shows all of the text when `line` is falsely, add `maxCalculateTimes` to prevent infinite loop
+* 0.12.1 Update peerDependencies to support React 16
+* 0.12.0 Added new prop: `textElement` for customize text render
+* 0.11.2 Fix truncate incorrect in small size of width
+* 0.11.0 Added two event hooks: `onTruncated` and `onCalculated`
+* 0.10.4 Support inline style
+* 0.10.3 Downgrade peerDependencies to `^15.4.1`
+* 0.10.2 Fix truncated wrong when font property changed
+* 0.10.1 Fix unknown prop `element`
+* 0.10.0 Allow pass `element` to specify root element type
+* 0.9.3 Fix SSR window not found (removed raf polyfill)
+* 0.9.2 Fix styles prop is not working when the text is not truncated
+* 0.9.1 Fix async this.forceUpdate() issue
+* 0.9.0 Fix infinity loop bug, upgrade react to 15.5.4 and support yarn
 * 0.8.3 IE 11 compatibility
 * 0.8.2 Fix wrong truncating when a container has long words without spaces
 * 0.8.1 Fix `textTruncateChild` bug
@@ -16,5 +31,5 @@
 * 0.3.7 Support CommonJS and UMD module loader
 * 0.3.5 Fix window resize issue
 * 0.3.4 supports Babel6
-* 0.2.0 supoorts React 0.14
+* 0.2.0 supports React 0.14
 * 0.1.5 supports React 0.13.3 and below


### PR DESCRIPTION
Looks like [this](https://github.com/ShinyChang/React-Text-Truncate/pull/62) moved the changelogs to a separate file but while doing so the new logs were deleted. This PR recovers them back. 