### PR TITLE
fix: specify correct prop-type for textElement

### DIFF
--- a/src/TextTruncate.js
+++ b/src/TextTruncate.js
@@ -10,7 +10,7 @@ export default class TextTruncate extends Component {
     onTruncated: PropTypes.func,
     onToggled: PropTypes.func,
     text: PropTypes.string,
-    textElement: PropTypes.node,
+    textElement: PropTypes.elementType,
     textTruncateChild: PropTypes.node,
     truncateText: PropTypes.string,
     maxCalculateTimes: PropTypes.number


### PR DESCRIPTION
The value of `textElement` prop is being used in `createElement()` function everywhere. That function accepts element type and not element ([from docs](https://reactjs.org/docs/react-api.html#createelement)).